### PR TITLE
Hide the failure sentinel in the typed install command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@ Installs on rotating Grok Bot 0.30.0 host builds without a per-hash approval.
 - The Mac and Windows installers read the Bot terminal through screenshot OCR. Attempt IDs now use only OCR-safe characters (no 0/O, 1/I, 5/S, 8/B, 7/T, 2/Z, 6/G), the failure marker matches on its stable prefix, and common digit/letter confusions are folded before comparison. Real beta.44 reports showed hex IDs like `7E0DBDB8` coming back as `TEODBDB8`, which hid the actual failed phase behind a generic "terminal stopped" message.
 - The completion timeout is now measured from the last observed phase instead of the start, so a slow first-time Codex dependency download no longer times out while it is still making progress.
 - The adapter-phase failure text tells users who previously installed OpenGrok or another router to run Restore Stock Grok Bot first.
+- The failure marker in the typed install command is now base64-encoded like the success marker. Public issue #7 showed the OCR loop reading `INSTALL_FAILED` from the still-visible command line and reporting "The Bot computer stopped before installation completed" while install.sh was still running and later succeeded.
 
 # GrokRouter 0.1.0-beta.45
 

--- a/installer-windows/main.cjs
+++ b/installer-windows/main.cjs
@@ -678,6 +678,10 @@ async function installRouter(executable, rawOptions) {
     const digest = crypto.createHash("sha256").update(archive).digest("hex");
     const installAttempt = makeInstallAttemptID();
     const installPayload = Buffer.from("\nGROKBOT_ROUTER_INSTALL_OK\n\nGROKBOT_ROUTER_INSTALL_OK\n").toString("base64");
+    // The typed command stays visible in the Bot terminal until output scrolls
+    // it away, and the OCR loop reads that text too. Keep every sentinel
+    // base64-encoded so the failure marker only appears when printed.
+    const failurePayload = Buffer.from(`\nGROKROUTER_${installAttempt}_INSTALL_FAILED_UNKNOWN_CODE_`, "utf8").toString("base64");
     const chunks = [];
     for (let index = 0; index < encoded.length; index += 1_000) chunks.push(encoded.slice(index, index + 1_000));
     const commands = ["mkdir -p /tmp/grokbot-router-installer", ": > /tmp/grokbot-router-installer/payload.b64"];
@@ -688,7 +692,7 @@ async function installRouter(executable, rawOptions) {
       "rm -rf /tmp/grokbot-router-installer/payload",
       "mkdir -p /tmp/grokbot-router-installer/payload",
       "tar -xzf /tmp/grokbot-router-installer/payload.tgz -C /tmp/grokbot-router-installer/payload --strip-components=1",
-      `if ROUTER_INSTALL_ATTEMPT=${installAttempt} bash /tmp/grokbot-router-installer/payload/remote/install.sh --provider ${options.defaultProvider} --providers ${options.providers.join(",")} --codex-model ${options.codexModel} --openrouter-model ${options.openRouterModel}; then clear; printf %s ${installPayload} | base64 -d; else code=$?; echo GROKROUTER_${installAttempt}_INSTALL_FAILED_UNKNOWN_CODE_$code; fi`,
+      `if ROUTER_INSTALL_ATTEMPT=${installAttempt} bash /tmp/grokbot-router-installer/payload/remote/install.sh --provider ${options.defaultProvider} --providers ${options.providers.join(",")} --codex-model ${options.codexModel} --openrouter-model ${options.openRouterModel}; then clear; printf %s ${installPayload} | base64 -d; else code=$?; printf %s ${failurePayload} | base64 -d; echo $code; fi`,
     );
     log("Transferring a SHA-256-verified payload into the Bot computer…");
     const installVNC = await typeRemoteCommandsResilient(commands, client, pageSession);

--- a/installer/GrokBotRouterInstaller.swift
+++ b/installer/GrokBotRouterInstaller.swift
@@ -1396,6 +1396,11 @@ final class RouterInstallerController: NSObject, NSApplicationDelegate {
         let digest = SHA256.hash(data: archive).map { String(format: "%02x", $0) }.joined()
         let installAttempt = Self.makeInstallAttemptID()
         let installPayload = Data("\nGROKBOT_ROUTER_INSTALL_OK\n\nGROKBOT_ROUTER_INSTALL_OK\n".utf8).base64EncodedString()
+        // The typed command itself stays visible in the Bot terminal until the
+        // output scrolls it away, and the OCR completion loop reads that text
+        // too. Keep every sentinel base64-encoded in the typed command so the
+        // failure marker can only appear when the installer actually prints it.
+        let failurePayload = Data("\nGROKROUTER_\(installAttempt)_INSTALL_FAILED_UNKNOWN_CODE_".utf8).base64EncodedString()
         // Short, quote-free commands always return to a usable shell prompt if
         // the VNC target changes mid-transfer. A retry starts from an empty file.
         var encodedChunks: [String] = []
@@ -1418,7 +1423,7 @@ final class RouterInstallerController: NSObject, NSApplicationDelegate {
             "rm -rf /tmp/grokbot-router-installer/payload",
             "mkdir -p /tmp/grokbot-router-installer/payload",
             "tar -xzf /tmp/grokbot-router-installer/payload.tgz -C /tmp/grokbot-router-installer/payload --strip-components=1",
-            "if ROUTER_INSTALL_ATTEMPT=\(installAttempt) bash /tmp/grokbot-router-installer/payload/remote/install.sh --provider \(defaultProvider) --providers \(providers) --codex-model \(codexModel) --openrouter-model \(openRouterModel); then clear; printf %s \(installPayload) | base64 -d; else code=$?; echo GROKROUTER_\(installAttempt)_INSTALL_FAILED_UNKNOWN_CODE_$code; fi"
+            "if ROUTER_INSTALL_ATTEMPT=\(installAttempt) bash /tmp/grokbot-router-installer/payload/remote/install.sh --provider \(defaultProvider) --providers \(providers) --codex-model \(codexModel) --openrouter-model \(openRouterModel); then clear; printf %s \(installPayload) | base64 -d; else code=$?; printf %s \(failurePayload) | base64 -d; echo $code; fi"
         ])
         appendLog("Transferring a SHA-256-verified payload into the Bot computer…")
         let installVNC = try await typeRemoteCommandsResilient(commands, client: client, pageSession: pageSession)

--- a/tests/installer.test.sh
+++ b/tests/installer.test.sh
@@ -85,6 +85,11 @@ grep -q 'only completion authority' "$PROJECT_ROOT/installer/GrokBotRouterInstal
 ! grep -q 'GROKBOT_ROUTER_COMMAND_ACCEPTED' "$PROJECT_ROOT/installer/GrokBotRouterInstaller.swift"
 grep -q 'installPayload.*base64EncodedString' "$PROJECT_ROOT/installer/GrokBotRouterInstaller.swift"
 grep -q 'installAttempt: installAttempt' "$PROJECT_ROOT/installer/GrokBotRouterInstaller.swift"
+grep -q 'let failurePayload = Data' "$PROJECT_ROOT/installer/GrokBotRouterInstaller.swift"
+grep -Fq 'printf %s \(failurePayload) | base64 -d; echo $code' "$PROJECT_ROOT/installer/GrokBotRouterInstaller.swift"
+# The typed command must never contain a plain-text sentinel: OCR reads the
+# echoed command line and would report a failure before install.sh finishes.
+! grep -q 'echo GROKROUTER_\\(installAttempt)_INSTALL_FAILED' "$PROJECT_ROOT/installer/GrokBotRouterInstaller.swift"
 grep -q 'INSTALLFAILED' "$PROJECT_ROOT/installer/GrokBotRouterInstaller.swift"
 grep -q 'Copy safe diagnostics' "$PROJECT_ROOT/installer/GrokBotRouterInstaller.swift"
 grep -q 'complete host fingerprint is included' "$PROJECT_ROOT/remote/install.sh"

--- a/tests/windows-installer.test.mjs
+++ b/tests/windows-installer.test.mjs
@@ -42,6 +42,11 @@ test("Windows installer preserves verified terminal transport and restore", () =
   assert.match(main, /typeRemoteCommandsResilient/);
   assert.match(main, /INSTALL_PHASES/);
   assert.match(main, /INSTALLFAILED/);
+  assert.match(main, /const failurePayload = Buffer\.from/);
+  assert.match(main, /printf %s \$\{failurePayload\} \| base64 -d; echo \$code/);
+  // The typed command must never carry a plain-text sentinel that OCR could
+  // read from the echoed command line before install.sh finishes.
+  assert.doesNotMatch(main, /echo GROKROUTER_\$\{installAttempt\}_INSTALL_FAILED/);
   assert.match(main, /Copy safe diagnostics/);
   assert.match(main, /typeRemoteCommand\("clear"/);
 });


### PR DESCRIPTION
## Why

Issue #7 reports "The Bot computer stopped before installation completed" at the adapter phase on a beta.45 install, with no `ERROR` line in the excerpt. The first line of that excerpt is the tail of the typed install command itself:

```
OUIRBTExfTOsK | base64 -d; else code=$?; echo GROKROUTER_A3A85AD5_INSTALL_FAILED
```

The Mac and Windows installers type one shell command into the Bot terminal and read the terminal back through screenshot OCR. That command ended with a plain-text `echo GROKROUTER_<ID>_INSTALL_FAILED_UNKNOWN_CODE_$code`. Whenever the echoed command line was still visible on screen (tall terminal, short install output), the OCR loop matched the failure marker and aborted while `install.sh` was still running. In #7 the install in fact finished: the reporter's Doctor says patched and `/provider` names a model. The abort also skipped native slash-command registration, so **Repair Router** is the right follow-up for that reporter.

## What changes

- The failure marker in the typed command is base64-encoded, exactly like the success marker already was, so it can only appear on screen when the installer prints it. Both the Mac (Swift) and Windows (Electron) installers change the same way.
- Tests assert that neither installer types a plain-text sentinel, and check the encoded form is present.
- Release notes for the unreleased beta.46 gain a bullet.

## Verification

Windows and installer test suites pass locally, plus a shell check that the new `else` branch still prints `GROKROUTER_<ID>_INSTALL_FAILED_UNKNOWN_CODE_<code>` on one line. The Swift typecheck runs in CI on macOS.

## Release note

The `source-v0.1.0-beta.46` tag has not been pushed yet, so this can still land inside beta.46: merge, then tag `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gjm11sHdkwN1HxmJgiPdZr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gjm11sHdkwN1HxmJgiPdZr)_