### PR TITLE
Add a workflow that creates the pinned source tag

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,55 @@
+name: Tag source release
+
+# Creates the annotated source tag that the README's pinned Terminal command
+# downloads. Run it from the Actions tab after the version bump has merged.
+# It refuses to tag a commit whose version fields disagree with the request.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version exactly as in package.json (for example 0.1.0-beta.46)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Verify the checked-out commit is the requested release
+        env:
+          REQUESTED: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$REQUESTED" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "Version '$REQUESTED' is not a valid release version" >&2
+            exit 1
+          fi
+          for file in package.json runtime/package.json installer-windows/package.json; do
+            actual="$(node -p "require('./$file').version")"
+            if [[ "$actual" != "$REQUESTED" ]]; then
+              echo "$file is $actual but $REQUESTED was requested" >&2
+              exit 1
+            fi
+          done
+          grep -Fq "SOURCE_REF=\"source-v$REQUESTED\"" scripts/install-macos.sh
+          grep -Fq "source-v$REQUESTED/scripts/install-macos.sh" README.md
+          if git ls-remote --exit-code --tags origin "source-v$REQUESTED" >/dev/null 2>&1; then
+            echo "Tag source-v$REQUESTED already exists; nothing to do" >&2
+            exit 1
+          fi
+      - name: Create and push the annotated source tag
+        env:
+          REQUESTED: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "source-v$REQUESTED" -m "GrokRouter source v$REQUESTED"
+          git push origin "source-v$REQUESTED"
+          echo "Tagged $(git rev-parse HEAD) as source-v$REQUESTED"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -25,6 +25,7 @@ If Xcode Command Line Tools are missing, macOS opens Apple's installer. The view
 8. Complete install → restore → reinstall with the exact build.
 9. Create a genuinely new Bot and complete `docs/FRESH-BOT-ACCEPTANCE.md`.
 10. Record the result in `docs/TEST-MATRIX.md`, commit, and wait for green CI.
+11. After the version bump has merged to `main`, create the source tag from the Actions tab: run **Tag source release** with the exact version (for example `0.1.0-beta.46`). The workflow refuses to tag a commit whose `package.json`, runtime and Windows package versions, `scripts/install-macos.sh` source ref, or README pinned command disagree with the requested version, and refuses an existing tag. Pushing the tag by hand from a clone with tag-push rights is equivalent.
 
 ## Compatibility changes
 


### PR DESCRIPTION
## Why

The README's install command downloads `scripts/install-macos.sh` from an exact `source-v<version>` tag, so a release is unusable until that tag exists. Issue #8 is exactly that gap: `main` has advertised beta.46 since the version bump merged, but no `source-v0.1.0-beta.46` tag has been published, so every new user gets a 404.

## What changes

- A manually dispatched **Tag source release** workflow (`.github/workflows/tag-release.yml`). It takes the exact version, verifies `package.json`, the runtime and Windows package versions, the installer `SOURCE_REF`, and the README pinned command all agree with it, refuses an existing tag, and then pushes the annotated `source-v<version>` tag from the checked-out commit. It requests `contents: write` only for itself.
- `docs/RELEASE.md` gains the step.

## Verification

YAML parses; Windows installer tests (which inspect `ci.yml`) still pass. The workflow runs only on manual dispatch, so it does not affect CI. First real run will be for `0.1.0-beta.46` on `main` right after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gjm11sHdkwN1HxmJgiPdZr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gjm11sHdkwN1HxmJgiPdZr)_