### PR TITLE
Promote the verified beta.47 install command and release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,28 @@
 
 GrokRouter is an experimental, unofficial, reversible model router. Each Bot remembers its own provider and model. Grok Bot continues to own conversations, files, the computer, permissions, and any outer tools it supplies to the routed model. Native maintenance sessions such as memory synthesis keep Grok's original inference backend.
 
-> **Maintenance candidate:** This branch prepares `0.1.0-beta.47`. It has passed the complete live acceptance procedure on official Grok Bot 0.30.0 and 0.36.0 and is awaiting publication. The pinned command below continues to reference the published beta.46 source until the replacement tag exists. beta.46 uses structural host acceptance; this candidate restores exact reviewed hash-and-size verification and repairs unsafe backup fallback.
+> **Source prerelease: beta.47.** Verified on official Grok Bot 0.30.0 and 0.36.0 with exact reviewed host fingerprints. [Release notes and source](https://github.com/promptadvisers/grokrouter/releases/tag/source-v0.1.0-beta.47) · [Dated verification](docs/TEST-MATRIX.md).
 
 ## Compatibility
 
 | Component | Current boundary |
 | --- | --- |
-| Grok Bot desktop | Published beta.46: **0.30.0**. Candidate beta.47: exact **0.30.0 and 0.36.0** gates, with separate complete live acceptance |
+| Grok Bot desktop | Exact official **0.30.0 and 0.36.0**, each independently live-verified |
 | macOS | Apple silicon, macOS 12+, Apple Command Line Tools |
 | Windows x64 / Arm64 | Source preview; CI packaging is separate from native installation verification |
 | Codex SDK | Sign in with your existing Codex account in the Bot computer |
 | OpenRouter | Your OpenRouter API key; provider usage is billed by OpenRouter |
 | Computer and sub-agents | Available only when Grok offers the necessary schemas; see the [verification matrix](docs/TEST-MATRIX.md) for provider-specific evidence |
 
-**Already updated Grok Bot?** The published beta.46 installer cannot support 0.36.0. This candidate adds a separately verified 0.36.0 desktop gate and signed host registry; it has passed the exact-artifact live acceptance gates. Other versions remain unsupported. Reports are tracked in [#1](https://github.com/promptadvisers/grokrouter/issues/1) and [#7](https://github.com/promptadvisers/grokrouter/issues/7). A successful source build does not establish compatibility with a newer Grok app or cloud host.
+**Already updated Grok Bot?** Beta.47 supports official 0.36.0 through a separate desktop gate and signed host registry. **0.44.0 and other unlisted versions are unsupported.** The desktop version and cloud host are separate checks: a supported app can still receive an unknown host, which the installer leaves untouched. See [compatibility reports](https://github.com/promptadvisers/grokrouter/issues?q=is%3Aissue+is%3Aopen+label%3Acompatibility).
 
 ## Install on a Mac
 
-1. Open the official Grok Bot **0.30.0** app from `/Applications`. Select a Bot, open its **Computer**, and leave it visible.
-2. Run the published source installer in your **Mac's Terminal**:
+1. Open the official Grok Bot **0.30.0 or 0.36.0** app from `/Applications`. Select a Bot, open its **Computer**, and leave it visible.
+2. Run the beta.47 source installer in your **Mac's Terminal**:
 
    ```bash
-   /usr/bin/curl --fail --silent --show-error --location https://raw.githubusercontent.com/promptadvisers/grokrouter/source-v0.1.0-beta.46/scripts/install-macos.sh --output /tmp/grokrouter-install.sh && /bin/bash /tmp/grokrouter-install.sh
+   /usr/bin/curl --fail --silent --show-error --location https://raw.githubusercontent.com/promptadvisers/grokrouter/source-v0.1.0-beta.47/scripts/install-macos.sh --output /tmp/grokrouter-install.sh && /bin/bash /tmp/grokrouter-install.sh
    ```
 
    This downloads tagged source, builds and signs the app locally, installs it at `~/Applications/GrokRouter.app`, and opens it. It does not need `sudo`. If Apple Command Line Tools are missing, finish Apple's installation and repeat the command.
@@ -42,7 +42,7 @@ GrokRouter is an experimental, unofficial, reversible model router. Each Bot rem
 
 The slash-suggestion menu is a convenience. If an entry is missing, type the complete command manually; a menu entry alone does not prove routing works.
 
-The ZIP alternative is **Code → Download ZIP → Install GrokRouter.command**. A ZIP from a development branch contains that branch's candidate, so use the tagged source for a published version. If macOS asks whether to open the command, Control-click it and choose **Open**. Do not disable Gatekeeper.
+The ZIP alternative is the release's **Source code (zip) → Install GrokRouter.command**. A ZIP from a development branch contains that branch's candidate, so use the tagged source for this prerelease. If macOS asks whether to open the command, Control-click it and choose **Open**. Do not disable Gatekeeper.
 
 ## Choose a model in chat
 
@@ -69,7 +69,7 @@ Use the **GrokRouter desktop app** for installation, health checks, repair, and 
 | Symptom | Next step |
 | --- | --- |
 | Unsupported app version | Stop and check the compatibility table. Reinstalling the same router cannot add version support. |
-| Unknown host hash or wrong byte count | Copy safe diagnostics. The candidate leaves the live host untouched, even if an old backup exists. A maintainer must review an exact host entry. |
+| Unknown host hash or wrong byte count | Copy safe diagnostics. The installer leaves the live host untouched, even if an old backup exists. A maintainer must review an exact host entry. |
 | Prior OpenGrok or another router | Do not layer routers. Use that router's documented removal or explicit verified stock restoration before attempting GrokRouter installation. |
 | Runtime version looks correct but adapter is stock or unknown | Runtime files and the live adapter are separate. Run desktop **Check health**. Repair succeeds only for a reviewed stock host or an exactly reconstructed supported router upgrade. |
 | Modified router with a valid stock backup | Automatic repair refuses it. Use explicit **Restore stock** if you intend to replace the live host, then install again on a supported version. |
@@ -85,11 +85,11 @@ For [installation support](https://github.com/promptadvisers/grokrouter/issues/n
 
 ## What verification means
 
-The candidate requires an exact reviewed **SHA-256 and byte count**, then checks every source anchor and syntax-checks the transformed file. Entries come from the bundled manifest or an Ed25519-signed compatibility registry. Structural similarity and a successful syntax check are diagnostic evidence; they do not authenticate an unknown file as stock vendor code.
+GrokRouter requires an exact reviewed **SHA-256 and byte count**, then checks every source anchor and syntax-checks the transformed file. Entries come from the bundled manifest or an Ed25519-signed compatibility registry. Structural similarity and a successful syntax check are diagnostic evidence; they do not authenticate an unknown file as stock vendor code.
 
 Router upgrades reconstruct the expected existing adapter from a trusted original. A marker string alone is insufficient. Doctor verifies the live adapter against that reconstruction and reports stock-backup health separately.
 
-The selected model can request only the outer tools Grok supplies for that turn. Grok still applies its permissions and performs those actions. A screenshot or sub-agent bridge in the source is not proof that every provider has passed those workflows. Historical and current results are kept in [TEST-MATRIX.md](docs/TEST-MATRIX.md).
+The selected model can request only the outer tools Grok supplies for that turn. Grok still applies its permissions and performs those actions. A screenshot or sub-agent bridge in the source is not proof that every provider has passed those workflows. Codex Sol and OpenRouter Claude passed real Shell, Read, Screenshot, and completed-child tests on both supported versions. Other models do not inherit those results. Exact receipts and provider limitations are in [TEST-MATRIX.md](docs/TEST-MATRIX.md).
 
 Provider credentials stay out of repository files, Bot state, and diagnostic logs. Routed conversation content is sent to the provider you choose. Read [SECURITY.md](SECURITY.md) and [HOW-IT-WORKS.md](docs/HOW-IT-WORKS.md) for the data boundary.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# GrokRouter 0.1.0-beta.47 — verified source candidate
+# GrokRouter 0.1.0-beta.47 — source prerelease
 
 - Restores exact reviewed host hash and byte-count verification. Structural diagnostics cannot authenticate a stock host.
 - Rejects an unknown or foreign live host even when a trusted old backup exists. Automatic repair cannot silently replace a newer incompatible host.
@@ -17,7 +17,7 @@
 - Makes source tagging depend on CI and a versioned acceptance record tied to the candidate's source digest. Keeps the existing download link until the new tag is available.
 - Adds CodeQL analysis, release validation tests, and clearer compatibility/recovery documentation.
 
-The unchanged final Mac artifact passed all seven required live gates independently on official Grok Bot 0.30.0 and 0.36.0. Codex Sol and OpenRouter Claude completed real computer tools and returned actual native child results once. Publication is pending the protected release workflow. Windows remains a source preview; 0.44.0 and unreviewed host hashes remain unsupported. Provider/helper limitations and exact receipts are recorded in [the verification matrix](docs/TEST-MATRIX.md).
+The unchanged final Mac artifact passed all seven required live gates independently on official Grok Bot 0.30.0 and 0.36.0. Codex Sol and OpenRouter Claude completed real computer tools and returned actual native child results once. Published September 9, 2026, after the protected release workflow passed. [Download tagged source](https://github.com/promptadvisers/grokrouter/releases/tag/source-v0.1.0-beta.47). Windows remains a source preview; 0.44.0 and unreviewed host hashes remain unsupported. Provider/helper limitations and exact receipts are recorded in [the verification matrix](docs/TEST-MATRIX.md).
 
 # GrokRouter 0.1.0-beta.46
 

--- a/docs/MAINTENANCE-STATUS.md
+++ b/docs/MAINTENANCE-STATUS.md
@@ -1,6 +1,6 @@
 # Beta.47 maintenance status
 
-The exact production source `644a9c4` passed every required Mac live gate on official Grok Bot 0.30.0 and 0.36.0 on September 9, 2026. The [acceptance record](release-acceptance.json) and [verification matrix](TEST-MATRIX.md) contain the release decision and limitations. Publication remains subject to the protected merge and tag workflow.
+The exact production source `644a9c4` passed every required Mac live gate on official Grok Bot 0.30.0 and 0.36.0 on September 9, 2026. The [acceptance record](release-acceptance.json) and [verification matrix](TEST-MATRIX.md) contain the release decision and limitations. PR #12 merged with all required checks passing. The protected tag workflow passed and [the source prerelease was published](https://github.com/promptadvisers/grokrouter/releases/tag/source-v0.1.0-beta.47) on September 9, 2026. The exact public install command downloaded, built, and installed successfully in an isolated test folder.
 
 ## Changes
 
@@ -24,7 +24,7 @@ The final artifact passed install → verified stock restore → reinstall, stri
 | #2 | Open: truncated host fingerprint is insufficient for an exact compatibility entry. |
 | #3 | Open: unknown/truncated host fingerprints and prior focus symptoms need exact safe diagnostics. |
 | #5 | Open: native Windows timeout and prior-router state remain unverified. Windows is a source preview. |
-| #7 | The official 0.36.0 version/Repair blocker is addressed and verified on the reviewed host. Reporter confirmation is distinct from maintainer acceptance. |
+| #7 | Closed: the official 0.36.0 version/Repair blocker is addressed and verified on the reviewed host. Reporter confirmation is distinct from maintainer acceptance. |
 | #8 | Closed: the exact pinned source download returned HTTP 200. This closes the download defect only. |
 
 The original implementation checkout and all unrelated local edits remain preserved; see [local-change reconciliation](LOCAL-CHANGE-RECONCILIATION.md). No proprietary host source or credentials are included in the repository or release payload.

--- a/docs/TEST-MATRIX.md
+++ b/docs/TEST-MATRIX.md
@@ -1,6 +1,6 @@
 # Verification matrix
 
-Verification lock: September 9, 2026. GrokRouter `0.1.0-beta.47`, production commit `644a9c4`. All seven required live gates passed independently on official Grok Bot **0.30.0 and 0.36.0** with the same Mac artifact. Publication is a separate step.
+Verification lock: September 9, 2026. GrokRouter `0.1.0-beta.47`, production commit `644a9c4`. All seven required live gates passed independently on official Grok Bot **0.30.0 and 0.36.0** with the same Mac artifact. The protected release workflow passed and the source prerelease was published September 9, 2026. See [publication verification](release-beta47-publication.md).
 
 Source digest: `86e10453fc44d718321226487aa7f7dd5d3572c900cc96d16fe55e857b48af02`.
 Mac test ZIP SHA-256: `7d648ff8f65cf1421f83c177c217d8f95c4620834be0eefd00164bee5e2b430f`.

--- a/docs/acceptance-beta47-644a9c4-0.36.0.md
+++ b/docs/acceptance-beta47-644a9c4-0.36.0.md
@@ -57,3 +57,12 @@ The addressed model switch returned at 10:14:46. B subsequently returned one pla
 One ancillary Codex memory-extraction task returned empty after its one allowed recovery at 10:14:40.388, producing a redacted helper error and host bridge diagnostic. The visible group command remained correct; no error bubble or state leak appeared. The next memory extraction completed at 10:14:52.781, episode summary at 10:14:59.244, and further memory tasks at 10:15:08.529 and 10:15:26.402, all without tools. This is recorded as a provider-empty limitation affecting that background memory pass, not omitted or represented as an error-free run. The required user-facing and routing gates passed.
 
 The clean-source installation listed above ran against official 0.36.0. All seven required gates are now verified for this exact candidate on 0.36.0. The immutable artifact must still complete the full independent 0.30.0 matrix before publication.
+
+
+## Final local restoration and Repair verification
+
+After the independent 0.30.0 acceptance, the same router explicitly restored the reviewed stock host again (`ok: true`, `status: restored`, stock hash `3364e421402302f8264f961637addb3997a817fde84a91b19635a0c28ff3941f`, `GROKBOT_ROUTER_UNINSTALL_OK`). Quitting applied Grok's queued 0.44.0 update; that application was preserved under its actual version. The official mounted 0.36.0 application was copied back only after vendor-signature and exact-version verification.
+
+The unchanged accepted beta.47 artifact then installed successfully on official 0.36.0 and registered six unique commands for 43 Bots/channels before host restart. Its explicit **Repair** action also succeeded and reconciled those six commands before restart. The following desktop Doctor's actual terminal receipt reported `hostAdapterVerified: true`, `stockBackupVerified: true`, `ok: true`, `status: installed`, supported version `0.36.0`, and `GROKBOT_ROUTER_DOCTOR_DONE`. Existing Codex sign-in and the protected OpenRouter credential remained configured. RC A036's Provider receipt at 11:04:43 UTC retained its prior OpenRouter Luna/medium selection.
+
+This verifies issue #7's official 0.36.0 Repair blocker on the exact reviewed host; it does not assert reporter confirmation or support for another host fingerprint. The accepted local installer was placed at `~/Applications/GrokRouter.app`, with the prior beta.45 app preserved in `~/Applications/GrokRouter Backups/`. The original source checkout and its unrelated edits remain untouched.

--- a/docs/release-beta47-publication.md
+++ b/docs/release-beta47-publication.md
@@ -1,0 +1,21 @@
+# Beta.47 publication verification
+
+Published September 9, 2026 at 11:14:19 UTC as a GitHub source prerelease:
+https://github.com/promptadvisers/grokrouter/releases/tag/source-v0.1.0-beta.47
+
+- Merged PR: #12.
+- Accepted main/tag commit: `d5cb8439d820f35611c7c20350e109d30239bd49`.
+- Immutable annotated tag: `source-v0.1.0-beta.47`.
+- PR CI: `34342888080`; CodeQL: `34342888092`; all required checks passed.
+- Protected tag workflow: `34343666279`; test/build, Windows packaging, and tag jobs all passed.
+- Production digest: `86e10453fc44d718321226487aa7f7dd5d3572c900cc96d16fe55e857b48af02`, identical to the final live-tested source `644a9c4`.
+- Public installer SHA-256: `37266f921e38e4cf5d80a2f39d4e8d24cb314da2530e16b7c4c8f27c5aed2a15`.
+- Downloaded public source ZIP SHA-256: `008f260265250823edeee62ae90d6587983957834f76a363f633921bcfbbe6c8`.
+
+The pinned raw installer and GitHub source archive both downloaded successfully after the tag existed. The extracted public source passed `verify-acceptance.mjs`; its installer bytes exactly matched the separately downloaded raw installer. Running that public installer outside a source checkout downloaded its tagged source, built the Mac app, installed it in an isolated test Applications directory, and passed signature verification. `GROKROUTER_NO_OPEN=1` prevented that verification from changing the user's active installer or live router.
+
+The README command was promoted only after those public-download checks. The source tag was not moved. No prebuilt unsigned Mac binary was attached; the public installer builds and ad-hoc signs locally. Windows remains a source preview despite successful package CI.
+
+Issue #7 was closed after the final artifact's official 0.36.0 Repair, native command reconciliation, strict Doctor, and preserved Provider receipt passed. This is maintainer verification on the exact reviewed host, not reporter confirmation. Issues #1, #2, #3, and #5 remain open for authenticated host evidence or native Windows acceptance. Issue #8's pinned-download defect was already closed separately.
+
+The original source checkout and local edits remain preserved. The accepted local beta.47 installer is at `~/Applications/GrokRouter.app`; beta.45 was retained in `~/Applications/GrokRouter Backups/`. The active official Grok Bot application was returned to vendor-verified 0.36.0 and the unchanged router passed reinstall, Repair, and strict Doctor.


### PR DESCRIPTION
Promotes the Mac install command to the now-published immutable beta.47 tag and replaces candidate wording with the exact verified compatibility and provider limits. The public raw installer and source archive downloaded successfully, the downloaded source passed the acceptance-digest validator, and the public installer downloaded, built, installed, and verified its app in an isolated Applications folder.

Records the protected release workflow, public download hashes, final official 0.36.0 Repair/Doctor evidence, and scoped issue disposition. This changes documentation only; the production digest remains identical to the live-accepted release. Local document links and release/acceptance validation pass.
